### PR TITLE
new en-OwO

### DIFF
--- a/en-OwO/BraytechActivityDefinition.json
+++ b/en-OwO/BraytechActivityDefinition.json
@@ -1,26 +1,26 @@
 {
   "1869786712": {
     "displayProperties": {
-      "name": "Hydwoponics Dewta",
-      "description": "Da Shadow Wegion haz bwoken into cwiticaw hydwoponics infwastwuctuwe, a pwoduction centwe fow Neomuni food suppwy. Secuwe da faciwity."
+      "description": "Da Shadow Wegion haz bwoken into cwiticaw hydwoponics infwastwuctuwe, a pwoduction centwe fow Neomuni food suppwy. Secuwe da faciwity.",
+      "name": "Hydwoponics Dewta"
     }
   },
   "2659723068": {
     "displayProperties": {
-      "name": "Gawden of Sawvation",
-      "description": "Da Gawden cawws out to uu. Answew decisivewy but exewcise caution."
+      "description": "Da Gawden cawws out to uu. Answew decisivewy but exewcise caution.",
+      "name": "Gawden of Sawvation"
     }
   },
   "2983905025": {
     "displayProperties": {
-      "name": "Giwded Pwecept",
-      "description": "\"What is da Eawth idiom? UwU Thwough a... miwwow? UwU\"\nFowbidden twadition. Da Shadow Wegion want to fight, so fight them."
+      "description": "\"What is da Eawth idiom? UwU Thwough a... miwwow? UwU\"\nFowbidden twadition. Da Shadow Wegion want to fight, so fight them.",
+      "name": "Giwded Pwecept"
     }
   },
   "584726932": {
     "displayProperties": {
-      "name": "Thwiwwadwome",
-      "description": "Sam Moweyn says they haz a thing cawwed \"Skee-Baww,\" and with enough points, uu can win pwizes. Ghost weawwy wants to come back when things \"cawm down.\""
+      "description": "Sam Moweyn says they haz a thing cawwed \"Skee-Baww,\" and with enough points, uu can win pwizes. Ghost weawwy wants to come back when things \"cawm down.\"",
+      "name": "Thwiwwadwome"
     }
   }
 }

--- a/en-OwO/BraytechCommonDefinition.json
+++ b/en-OwO/BraytechCommonDefinition.json
@@ -1,74 +1,91 @@
 {
   "accurate-gear-power-average": {
     "displayProperties": {
-      "name": "Geaw Powew",
-      "description": "*bwushes* Da avewage Powew wevew of uuw cuwwentwy equipped awmaments.\nFow an accuwate vawue, uuw inventowy is assessed. If uuw inventowy is not pubwic, uu'ww need to authenticate with Bungie.net."
+      "description": "*bwushes* Da avewage Powew wevew of uuw cuwwentwy equipped awmaments.\nFow an accuwate vawue, uuw inventowy is assessed. If uuw inventowy is not pubwic, uu'ww need to authenticate with Bungie.net.",
+      "name": "Geaw Powew"
     }
   },
   "active-triumph-score": {
     "displayProperties": {
-      "name": "Active Twiumph Scowe",
-      "description": "Da cuwwent vawue of aww active Twiumphs that haz been eawned and da totaw vawue of aww active twiumphs.\n\nThese scowe vawues change when Twiumphs become wegacy Twiumphs."
+      "description": "Da cuwwent vawue of aww active Twiumphs that haz been eawned and da totaw vawue of aww active twiumphs.\n\nThese scowe vawues change when Twiumphs become wegacy Twiumphs.",
+      "name": "Active Twiumph Scowe"
     }
   },
   "activity-contest-mode": {
     "displayProperties": {
-      "name": "Amongst da Fiwst",
-      "description": "This activity was finished in da contest mode window: twiumph undew extwaowdinawy ciwcumstance and pwessuwe"
+      "description": "This activity was finished in da contest mode window: twiumph undew extwaowdinawy ciwcumstance and pwessuwe",
+      "name": "Amongst da Fiwst"
+    }
+  },
+  "activity-duo": {
+    "displayProperties": {
+      "description": "_Wun it back to back._"
     }
   },
   "activity-flawless": {
     "displayProperties": {
-      "name": "Deathwess",
-      "description": "This activity was stawted fwom its beginning and finished fwawwesswy, with no deaths.\n\nTo be ewigibwe, **waids** must be compweted aftew da waunch of Witch Queen, **dungeons** and **wost sectows** must be stawted and finished by a singwe (・`ω´・) pwayew, *wuns away* and **stwikes** awe specific to each pwayew."
+      "description": "This activity was stawted fwom its beginning and finished fwawwesswy, with no deaths.\n\nTo be ewigibwe, **waids** must be compweted aftew da waunch of Witch Queen, **dungeons** and **wost sectows** must be stawted and finished by a singwe (・`ω´・) pwayew, *wuns away* and **stwikes** awe specific to each pwayew.",
+      "name": "Deathwess"
+    }
+  },
+  "activity-solo": {
+    "displayProperties": {
+      "description": "_Widing sowo. This guawdian is so cwacked they don't need no stinkin' fiweteam._",
+      "name": "Sowo"
+    }
+  },
+  "activity-trio": {
+    "displayProperties": {
+      "description": "_It's a thweesome._",
+      "name": "Twio"
     }
   },
   "activity-weapon-popular": {
     "displayProperties": {
-      "name": "Finaw Bwows",
-      "description": "_This weapon is so hot wight now._\n\nSum of finaw bwows by combatants using this weapon.\n\nOutwiews awe detewmined with da fowmuwa: \n`Sum of weapon finaw bwows >= Q3 + IQW`"
+      "description": "_This weapon is so hot wight now._\n\nSum of finaw bwows by combatants using this weapon.\n\nOutwiews awe detewmined with da fowmuwa: \n`Sum of weapon finaw bwows \u003e= Q3 + IQW`",
+      "name": "Finaw Bwows"
     }
   },
   "add-record-bookmark": {
     "displayProperties": {
-      "name": "Add Bookmawk",
-      "description": "Bookmawk this wecowd fow watew viewing.\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app."
+      "description": "Bookmawk this wecowd fow watew viewing.\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app.",
+      "name": "Add Bookmawk"
     }
   },
   "add-record-track": {
     "displayProperties": {
-      "name": "Twack Wecowd",
-      "description": "Add this wecowd to \"Twacked Wecowds\"\nIf enabwed, this *boops uuw nose* action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app."
+      "description": "Add this wecowd to \"Twacked Wecowds\"\nIf enabwed, this *boops uuw nose* action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app.",
+      "name": "Twack Wecowd"
     }
   },
   "ammo-type-primary": {
     "displayProperties": {
-      "name": "Pwimawy",
-      "description": "This weapon haz infinite wesewves."
+      "description": "This weapon haz infinite wesewves.",
+      "name": "Pwimawy"
     }
   },
   "ammo-type-special": {
     "displayProperties": {
-      "name": "Speciaw",
-      "description": "This weapon uses speciaw ammo."
+      "description": "This weapon uses speciaw ammo.",
+      "name": "Speciaw"
     }
   },
   "artifact-power-bonus": {
     "displayProperties": {
-      "name": "Awtifact Powew Bonus",
-      "description": "Eawning XP gwants Powew bonuses and unwocks powewfuw mods on uuw seasonaw awtifact."
+      "description": "Eawning XP gwants Powew bonuses and unwocks powewfuw mods on uuw seasonaw awtifact.",
+      "name": "Awtifact Powew Bonus"
     }
   },
   "character-loadouts-delete": {
     "displayProperties": {
-      "name": "Dewete Woadout",
-      "description": "Dewete this woadout. This action is pewmanent."
+      "description": "Dewete this woadout. This action is pewmanent.",
+      "name": "Dewete Woadout"
     }
   },
   "commonality": {
     "displayProperties": {
-      "name": "Commonawity",
-      "description": "Pewcentage of pwayews who awe indexed by Vowuspa who've acquiwed ow wedeemed this entwy."
+      "description": "Pewcentage of pwayews who awe indexed by Vowuspa who've acquiwed ow wedeemed this entwy.",
+      "name": "Commonawity"
     }
   },
   "configure-push-notifications": {
@@ -78,40 +95,68 @@
   },
   "enable-dim-sync": {
     "displayProperties": {
-      "name": "DIM Sync Wequiwed",
-      "description": "This featuwe wequiwes _DIM Sync_.\n\nEnabwe da sewvice in _Settings_."
+      "description": "This featuwe wequiwes _DIM Sync_.\n\nEnabwe da sewvice in _Settings_.",
+      "name": "DIM Sync Wequiwed"
     }
   },
   "expiration": {
     "displayProperties": {
-      "name": "Expiwation",
-      "description": "This wecowd haz expiwation infowmation attached."
+      "description": "This wecowd haz expiwation infowmation attached.",
+      "name": "Expiwation"
     }
+  },
+  "flair-api-dev": {
+    "displayProperties": {
+      "description": "_Bewawe da Awchitects._\nThis pwayew buiwds with Bungie's API.",
+      "name": "Bungie API Devewopew"
+    },
+    "itemTypeDisplayName": "Speciaw"
+  },
+  "flair-bungie": {
+    "displayProperties": {
+      "description": "_Bewawe da Awchitects._\nThis pwayew _couwd_ dewete uu.",
+      "name": "Bungie Devewopew"
+    },
+    "itemTypeDisplayName": "Speciaw"
+  },
+  "flair-charitable": {
+    "displayProperties": {
+      "description": "_A chawitabwe Guawdian._\nThis pwayew made a donation to a gweat cause via da Bungie Foundation.",
+      "name": "Benefactow"
+    },
+    "itemTypeDisplayName": "Speciaw"
   },
   "flair-cryptarch": {
     "displayProperties": {
-      "name": "Cwyptawch",
-      "description": "_A genewous twanswatow of Bwaytech._"
+      "description": "_A genewous twanswatow of Bwaytech._",
+      "name": "Cwyptawch"
     },
     "itemTypeDisplayName": "Bwaytech Twanswatow"
   },
   "flair-developer": {
     "displayProperties": {
-      "description": "_Cweatow of Bwaytech._"
+      "description": "_Cweatow of Bwaytech._\nThis pwayew cweated da app thwough which uu'we weading this toowtip."
     },
     "itemTypeDisplayName": "Bwaytech Devewopew"
   },
+  "flair-for-you": {
+    "displayProperties": {
+      "description": "_Uu'we my wittwe pogchamp, Guawdian._ 🌞",
+      "name": "\"I made this fow uu\""
+    },
+    "itemTypeDisplayName": "Speciaw"
+  },
   "flair-patron": {
     "displayProperties": {
-      "name": "Patwon",
-      "description": "An invawuabwe Patweon subscwibew."
+      "description": "An invawuabwe Patweon subscwibew.",
+      "name": "Patwon"
     },
     "itemTypeDisplayName": "Bwaytech Suppowtew"
   },
   "flair-patron-researcher": {
     "displayProperties": {
-      "name": "Weseawchew",
-      "description": "_One of few suwviving weseawchews who've escaped da tweachewy of Cwovis Bway._\nAn invawuabwe Patweon subscwibew."
+      "description": "_One of few suwviving weseawchews who've escaped da tweachewy of Cwovis Bway._\nAn invawuabwe Patweon subscwibew.",
+      "name": "Weseawchew"
     },
     "itemTypeDisplayName": "Bwaytech Suppowtew"
   },
@@ -123,32 +168,32 @@
   },
   "interval-score": {
     "displayProperties": {
-      "name": "Scowe Vawue",
-      "description": "This wecowd's wemaining scowe vawue (sum of wemaining intewvaws)."
+      "description": "This wecowd's wemaining scowe vawue (sum of wemaining intewvaws).",
+      "name": "Scowe Vawue"
     }
   },
   "latent-memories": {
     "displayProperties": {
-      "name": "Watent Memowies",
-      "description": "Mystewious test nodes awe scattewed acwoss Maws. (・`ω´・) What is theiw puwpose? UwU"
+      "description": "Mystewious test nodes awe scattewed acwoss Maws. (・`ω´・) What is theiw puwpose? UwU",
+      "name": "Watent Memowies"
     }
   },
   "legacy-triumph-score": {
     "displayProperties": {
-      "name": "Wegacy Twiumph Scowe",
-      "description": "Totaw scowe of aww compweted wegacy Twiumphs."
+      "description": "Totaw scowe of aww compweted wegacy Twiumphs.",
+      "name": "Wegacy Twiumph Scowe"
     }
   },
   "lifetime-triumph-score": {
     "displayProperties": {
-      "name": "Wifetime Twiumph Scowe",
-      "description": "A combination of aww compweted active and wegacy Twiumph scowes."
+      "description": "A combination of aww compweted active and wegacy Twiumph scowes.",
+      "name": "Wifetime Twiumph Scowe"
     }
   },
   "platform-battlenet": {
     "displayProperties": {
-      "name": "Battwe.net",
-      "description": "Da pwatfowm to which this pwofiwe bewongs."
+      "description": "Da pwatfowm to which this pwofiwe bewongs.",
+      "name": "Battwe.net"
     },
     "itemTypeDisplayName": "Pwatfowm"
   },
@@ -160,8 +205,8 @@
   },
   "platform-playstation": {
     "displayProperties": {
-      "name": "Pwaystation",
-      "description": "Da pwatfowm to which this pwofiwe bewongs."
+      "description": "Da pwatfowm to which this pwofiwe bewongs.",
+      "name": "Pwaystation"
     },
     "itemTypeDisplayName": "Pwatfowm"
   },
@@ -185,32 +230,32 @@
   },
   "presentation-node-score": {
     "displayProperties": {
-      "name": "Scowe Vawue",
-      "description": "This node's cawcuwated scowe vawue."
+      "description": "This node's cawcuwated scowe vawue.",
+      "name": "Scowe Vawue"
     }
   },
   "profile-stale": {
     "displayProperties": {
-      "name": "Stawe Pwofiwe",
-      "description": "An attempt to update uuw pwofiwe data with Bungie.net faiwed. Bwaytech was unabwe to weach Bungie.net.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting."
+      "description": "An attempt to update uuw pwofiwe data with Bungie.net faiwed. Bwaytech was unabwe to weach Bungie.net.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting.",
+      "name": "Stawe Pwofiwe"
     }
   },
   "profile-stale-inactive": {
     "displayProperties": {
-      "name": "Stawe Pwofiwe",
-      "description": "Backgwound wefwesh is paused due to inactivity. Intewact with Bwaytech to weactivate da sewvice."
+      "description": "Backgwound wefwesh is paused due to inactivity. Intewact with Bwaytech to weactivate da sewvice.",
+      "name": "Stawe Pwofiwe"
     }
   },
   "profile-stale-maintenance": {
     "displayProperties": {
-      "name": "Stawe Pwofiwe",
-      "description": "Bungie.net is tempowawiwy unavaiwabwe due to maintenance.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting."
+      "description": "Bungie.net is tempowawiwy unavaiwabwe due to maintenance.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting.",
+      "name": "Stawe Pwofiwe"
     }
   },
   "profile-stale-minted": {
     "displayProperties": {
-      "name": "Stawe Pwofiwe",
-      "description": "Bungie.net wetuwned owd infowmation.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting."
+      "description": "Bungie.net wetuwned owd infowmation.\n\nContinued use of Bwaytech may wesowve this issue, Bungie.net sewvice avaiwabiwity pewmitting.",
+      "name": "Stawe Pwofiwe"
     }
   },
   "progression-step-map": {
@@ -218,239 +263,76 @@
       "description": "_This map chawts da steps on da path to da top._"
     }
   },
+  "push-notification-event-daily-lost-sector": {
+    "displayProperties": {
+      "description": "Nevew miss a wotating wost sectow ow wewawd again.",
+      "name": "Wost *sweats* Sectows"
+    }
+  },
+  "push-notification-event-weekly-crucible": {
+    "displayProperties": {
+      "description": "Be notified of which *boops uuw nose* modes Wowd *boops uuw nose* Shaxx haz configuwed da Cwucibwe fow.\n\nFight fow fame and gwowy, but in oddwy specific ways and at a weekwy cadence.",
+      "name": "Cwucibwe"
+    }
+  },
+  "push-notification-event-weekly-vendor-ada1-shaders": {
+    "displayProperties": {
+      "description": "How dwippy uu wook is onwy wimited by uuw choice in shadews. Keep in contact with Ada in case uu'we missing da goods.",
+      "name": "Ada-1 Shadews"
+    }
+  },
+  "push-notification-event-weekly-vendor-xur": {
+    "displayProperties": {
+      "description": "A peddwew of stwange cuwios, Xûw's motives awe not his own. He bows to his distant mastews, da Nine.",
+      "name": "Xûw"
+    }
+  },
   "record-intervals": {
     "displayProperties": {
-      "name": "Wecowd intewvaws",
-      "description": "Some wecowds haz intewvaws. Diffewent intewvaws haz vawied wequiwements and scowe vawues."
+      "description": "Some wecowds haz intewvaws. Diffewent intewvaws haz vawied wequiwements and scowe vawues.",
+      "name": "Wecowd intewvaws"
     }
   },
   "remove-record-bookmark": {
     "displayProperties": {
-      "name": "Wemove Bookmawk",
-      "description": "Wemove this bookmawk.\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app."
+      "description": "Wemove this bookmawk.\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app.",
+      "name": "Wemove Bookmawk"
     }
   },
   "remove-record-track": {
     "displayProperties": {
-      "name": "Untwack Wecowd",
-      "description": "Wemove this wecowd fwom \"Twacked Wecowds\"\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app."
+      "description": "Wemove this wecowd fwom \"Twacked Wecowds\"\nIf enabwed, this action syncs with uuw Bwaytech pwofiwe and wiww be wefwected whewevew uu use da app.",
+      "name": "Untwack Wecowd"
     }
   },
   "score": {
     "displayProperties": {
-      "name": "Scowe Vawue",
-      "description": "This wecowd's scowe vawue."
+      "description": "This wecowd's scowe vawue.",
+      "name": "Scowe Vawue"
     }
   },
   "stat-damage-falloff": {
     "displayProperties": {
-      "name": "Damage Fawwoff",
-      "description": "Appwoximate distances whewe damage fawwoff begins fow hipfiwe and ADS (aim down sights)."
+      "description": "Appwoximate distances whewe damage fawwoff begins fow hipfiwe and ADS (aim down sights).",
+      "name": "Damage Fawwoff"
     }
   },
   "stat-reload-time": {
     "displayProperties": {
-      "name": "Wewoad Time",
-      "description": "Da time it takes fow this weapon to compwete a fuww wewoad *boops uuw nose* and fiwe. This vawue is based onwy on da wewoad speed stat and is unaffected by pewks."
-    }
-  },
-  "sub-activity-bookmarks": {
-    "displayProperties": {
-      "name": "Bookmawks",
-      "description": "A wecowd of uuw victowies, satisfaction, and dismay.\n\nHewe wies aww *wuns away* activities which uu've added to uuw bookmawks. Stand taww, Guawdian, and bask in uuw gwowy."
-    }
-  },
-  "sub-activity-carnage": {
-    "displayProperties": {
-      "name": "Cawnage",
-      "description": "Aww of da sewected Guawdian's wecent activities."
-    }
-  },
-  "sub-activity-graphs": {
-    "displayProperties": {
-      "name": "Gwaphs",
-      "description": "Activities pwotted against gwaphs, fow da statisticawwy incwined."
-    }
-  },
-  "sub-activity-series": {
-    "displayProperties": {
-      "name": "Sewies",
-      "description": "Twiumph undew da most pewiwous conditions, wepowts of uuw fiweteams' fiwst victowies against ouw gweatest advewsawies."
-    }
-  },
-  "sub-character-consumables": {
-    "displayProperties": {
-      "name": "Consumabwes",
-      "description": "Suppwies and matewiaws that can be used to enhance uuw Guawdian and theiw geaw"
-    }
-  },
-  "sub-character-equipment": {
-    "displayProperties": {
-      "description": "Evawuate uuw Guawdian's battwe weadiness"
-    }
-  },
-  "sub-character-loadouts": {
-    "displayProperties": {
-      "name": "Woadouts",
-      "description": "Pweconfiguwe uuw equipment, stwap it up, and name it"
-    }
-  },
-  "sub-character-postmaster": {
-    "displayProperties": {
-      "name": "Postmastew",
-      "description": "Postmastew Fwames dutifuwwy ovewsee dewivewies, messages, and wost items"
-    }
-  },
-  "sub-character-vault": {
-    "displayProperties": {
-      "name": "Vauwt",
-      "description": "Safe stowage fow genewaw items. Accessibwe to aww uuw chawactews"
-    }
-  },
-  "sub-character-vendors": {
-    "displayProperties": {
-      "name": "Vendows",
-      "description": "Spy on uuw favouwite task dewegatows and twading pawtnews"
-    }
-  },
-  "sub-clan-about": {
-    "displayProperties": {
-      "name": "Cwan",
-      "description": "About uuw cwan and what it stands fow"
-    }
-  },
-  "sub-clan-administration": {
-    "displayProperties": {
-      "name": "Administwation",
-      "description": "Take action on cwan mattews and membews"
-    }
-  },
-  "sub-clan-relationships": {
-    "displayProperties": {
-      "name": "Wewationships",
-      "description": "See which cwan membews uu dedicate uuw time to most"
-    }
-  },
-  "sub-clan-roster": {
-    "displayProperties": {
-      "name": "Wostew",
-      "description": "Find fwiends to pway with"
-    }
-  },
-  "sub-clan-stats": {
-    "displayProperties": {
-      "name": "Histowicaw Stats",
-      "description": "Compawe _Histowicaw Stats_ fow sevewaw activity modes acwoss aww cwan membews"
-    }
-  },
-  "sub-collections-exotic-catalysts": {
-    "displayProperties": {
-      "name": "Pattewns & Catawysts",
-      "description": "Pattewns enabwe da shaping of weapons. Catawysts expand da powew of uuw Exotic weapons. Find them and finish theiw objectives to unwock uuw awsenaw's fuww potentiaw"
-    }
-  },
-  "sub-collections-lore": {
-    "displayProperties": {
-      "name": "Wowe",
-      "description": "Wowe tewws bwoadew stowies fwom da Destiny univewse. Unwock and wead wowe pages by compweting Twiumphs"
-    }
-  },
-  "sub-collections-medals": {
-    "displayProperties": {
-      "name": "Medaws",
-      "description": "Medaws awe eawned thwough feats of gamepway expewtise. See da wist of medaws and how many of each uu've eawned"
-    }
-  },
-  "sub-collections-metrics": {
-    "displayProperties": {
-      "name": "Stat Twackews",
-      "description": "Stat twackews can be appwied to uuw embwem fwom its inspect view. Appwied twackews wiww appeaw on uuw namepwate whenevew visibwe"
-    }
-  },
-  "sub-collections-root": {
-    "displayProperties": {
-      "name": "Cowwections",
-      "description": "Items uuw Guawdian haz acquiwed ovew theiw wifetime"
-    }
-  },
-  "sub-inspect-equipment": {
-    "displayProperties": {
-      "description": "Aww item attwibutes; stats, pewks, and mods"
-    }
-  },
-  "sub-inspect-lore": {
-    "displayProperties": {
-      "name": "Wowe",
-      "description": "Wead this item's stowy"
-    }
-  },
-  "sub-settings-advanced": {
-    "displayProperties": {
-      "description": "Pewfowmance, debugging, and stowage management. No one haz fun hewe."
-    }
-  },
-  "sub-settings-common": {
-    "displayProperties": {
-      "description": "Destiny pwofiwe, settings synchwonisation, wanguage, item visibiwity, theme, and mowe—these settings affect how uu enjoy *wuns away* Bwaytech."
-    }
-  },
-  "sub-settings-push-notifications": {
-    "displayProperties": {
-      "description": "Contwow how Bwaytech weaches uu when uu'we not using it."
-    }
-  },
-  "sub-triumphs-active": {
-    "displayProperties": {
-      "name": "Active Twiumphs and Seaws",
-      "description": "View aww active Twiumphs and Seaws"
-    }
-  },
-  "sub-triumphs-event-card": {
-    "displayProperties": {
-      "name": "Active Event Cawd",
-      "description": "Compwete wimited-time Event Cawd chawwenges to eawn vawious wewawds and make pwogwess towawd event Seaw compwetion."
-    }
-  },
-  "sub-triumphs-legacy": {
-    "displayProperties": {
-      "name": "Wegacy Twiumphs and Seaws",
-      "description": "View a cowwection of wegacy Twiumphs and Seaws"
-    }
-  },
-  "sub-triumphs-transient": {
-    "displayProperties": {
-      "name": "Twansient Twiumphs",
-      "description": "Not aww Twiumphs awe fowevew–compwete these wecowds with hazte ow be wost fowevew in time."
-    }
-  },
-  "sub-weeklies-challenges": {
-    "displayProperties": {
-      "name": "Chawwenges",
-      "description": "Aww activity chawwenges"
-    }
-  },
-  "sub-weeklies-rotations": {
-    "displayProperties": {
-      "name": "Wotations",
-      "description": "Scwy da owbits of vawious activities"
-    }
-  },
-  "sub-weeklies-seasonal-challenges": {
-    "displayProperties": {
-      "name": "Seasonaw Chawwenges",
-      "description": "Compwete wimited-time chawwenges fow Season wank, Bwight Dust, and othew wewawds"
+      "description": "Da time it takes fow this weapon to compwete a fuww wewoad *boops uuw nose* and fiwe. This vawue is based onwy on da wewoad speed stat and is unaffected by pewks.",
+      "name": "Wewoad Time"
     }
   },
   "tooltip-error": {
     "displayProperties": {
-      "name": "Unknown Ewwow",
-      "description": "An ewwow occuwwed whiwe wendewing this toowtip.\n\nThis is pwobabwy a tempowawy ewwow. Apowogies."
+      "description": "An ewwow occuwwed whiwe wendewing this toowtip.\n\nThis is pwobabwy a tempowawy ewwow. Apowogies.",
+      "name": "Unknown Ewwow"
     }
   },
   "total-resets": {
     "displayProperties": {
-      "name": "Totaw wesets",
-      "description": "Aww seasons' wesets. Twacks fwom Season 4 onwawd."
+      "description": "Aww seasons' wesets. Twacks fwom Season 4 onwawd.",
+      "name": "Totaw wesets"
     }
   }
 }

--- a/en-OwO/BraytechFeatureDefinition.json
+++ b/en-OwO/BraytechFeatureDefinition.json
@@ -2,203 +2,200 @@
   "activity": {
     "displayProperties": {
       "description": "Expwowe and *wuns away* fiwtew uuw Post Game Cawnage Wepowts in detaiw"
-    },
-    "keywords": [
-      "reports",
-      "pgcr",
-      "raids",
-      "lost sectors",
-      "nightfalls",
-      "strikes",
-      "crucible",
-      "trials",
-      "competitive",
-      "matches",
-      "reputation",
-      "ranks"
-    ]
+    }
   },
   "activity-bookmarks": {
     "displayProperties": {
-      "name": "Bookmawks",
-      "description": "Activities uu've bookmawked"
-    },
-    "keywords": [
-      "reports",
-      "pgcr",
-      "raids",
-      "lost sectors",
-      "nightfalls",
-      "strikes",
-      "crucible",
-      "trials",
-      "competitive",
-      "matches"
-    ]
+      "description": "A wecowd of uuw victowies, satisfaction, and dismay.\n\nHewe wies aww *wuns away* activities which uu've added to uuw bookmawks. Stand taww, Guawdian, and bask in uuw gwowy.",
+      "name": "Bookmawks"
+    }
+  },
+  "activity-carnage": {
+    "displayProperties": {
+      "description": "Aww of da sewected Guawdian's wecent activities.",
+      "name": "Cawnage"
+    }
+  },
+  "activity-graphs": {
+    "displayProperties": {
+      "description": "Activities pwotted against gwaphs, fow da statisticawwy incwined.",
+      "name": "Gwaphs"
+    }
   },
   "activity-series": {
     "displayProperties": {
-      "name": "Sewies",
-      "description": "Twiumph undew da most pewiwous conditions, wepowts of uuw fiweteams' fiwst victowies against ouw gweatest advewsawies"
-    },
-    "keywords": [
-      "reports",
-      "pgcr",
-      "stats",
-      "raids",
-      "lost sectors",
-      "nightfalls",
-      "strikes",
-      "fireteams",
-      "day 1s",
-      "contest mode",
-      "completions",
-      "flawlesses",
-      "matches"
-    ]
+      "description": "Twiumph undew da most pewiwous conditions, wepowts of uuw fiweteams' fiwst victowies against ouw gweatest advewsawies",
+      "name": "Sewies"
+    }
   },
   "archives": {
     "displayProperties": {
-      "name": "Awchives",
-      "description": "Intewactive toows, manuaws, wegends, and othew content, pwesewved by da Cwyptawchs fow futuwe genewations"
+      "description": "Intewactive toows, manuaws, wegends, and othew content, pwesewved by da Cwyptawchs fow futuwe genewations",
+      "name": "Awchives"
     }
   },
   "character": {
     "displayProperties": {
-      "name": "Chawactew",
-      "description": "Weview uuw Guawdian's equipment and inventowy"
-    },
-    "keywords": [
-      "inventory",
-      "items",
-      "equipment",
-      "stats"
-    ]
+      "description": "Weview uuw Guawdian's equipment and inventowy",
+      "name": "Chawactew"
+    }
+  },
+  "character-consumables": {
+    "displayProperties": {
+      "description": "Suppwies and matewiaws that can be used to enhance uuw Guawdian and theiw geaw",
+      "name": "Consumabwes"
+    }
+  },
+  "character-equipment": {
+    "displayProperties": {
+      "description": "Evawuate uuw Guawdian's battwe weadiness"
+    }
+  },
+  "character-loadouts": {
+    "displayProperties": {
+      "description": "Pweconfiguwe uuw equipment, stwap it up, and name it",
+      "name": "Woadouts"
+    }
   },
   "character-postmaster": {
     "displayProperties": {
-      "name": "Postmastew",
-      "description": "Postmastew Fwames dutifuwwy ovewsee dewivewies, messages, and wost items"
-    },
-    "keywords": [
-      "postmaster"
-    ]
+      "description": "Postmastew Fwames dutifuwwy ovewsee dewivewies, messages, and wost items",
+      "name": "Postmastew"
+    }
   },
   "character-vault": {
     "displayProperties": {
-      "name": "Vauwt",
-      "description": "Safe stowage fow genewaw items. Accessibwe to aww uuw chawactews"
-    },
-    "keywords": [
-      "vault"
-    ]
+      "description": "Safe stowage fow genewaw items. Accessibwe to aww uuw chawactews",
+      "name": "Vauwt"
+    }
   },
   "character-vendors": {
     "displayProperties": {
-      "name": "Vendows",
-      "description": "Spy on uuw favouwite task dewegatows and twading pawtnews"
-    },
-    "keywords": [
-      "vendors",
-      "bright dust calendar",
-      "eververse calendar"
-    ]
+      "description": "Spy on uuw favouwite task dewegatows and twading pawtnews",
+      "name": "Vendows"
+    }
   },
   "checklists": {
     "displayProperties": {
-      "name": "Checkwists",
-      "description": "Ghost scans and item checkwists spanning da Sow system"
-    },
-    "keywords": [
-      "eggs",
-      "ahamkara bones",
-      "region chests",
-      "lost sectors"
-    ]
+      "description": "Ghost scans and item checkwists spanning da Sow system",
+      "name": "Checkwists"
+    }
   },
   "clan": {
     "displayProperties": {
-      "name": "Cwan",
-      "description": "About uuw cwan, its wostew, summative histowicaw stats fow aww membews, and admin mode"
+      "description": "About uuw cwan, its wostew, summative histowicaw stats fow aww membews, and admin mode",
+      "name": "Cwan"
+    }
+  },
+  "clan-about": {
+    "displayProperties": {
+      "description": "About uuw cwan and what it stands fow",
+      "name": "Cwan"
+    }
+  },
+  "clan-relationships": {
+    "displayProperties": {
+      "description": "See which cwan membews uu dedicate uuw time to most",
+      "name": "Wewationships"
+    }
+  },
+  "clan-roster": {
+    "displayProperties": {
+      "description": "Find fwiends to pway with",
+      "name": "Wostew"
+    }
+  },
+  "clan-roster-admin": {
+    "displayProperties": {
+      "description": "Take action on cwan mattews and membews",
+      "name": "Administwation"
+    }
+  },
+  "clan-stats": {
+    "displayProperties": {
+      "description": "Compawe _Histowicaw Stats_ fow sevewaw activity modes acwoss aww cwan membews",
+      "name": "Histowicaw Stats"
     }
   },
   "collections": {
     "displayProperties": {
-      "name": "Cowwections",
-      "description": "Items uuw Guawdian haz acquiwed ovew theiw wifetime"
-    },
-    "keywords": [
-      "exotics",
-      "badges",
-      "trackers",
-      "emblem",
-      "catalysts",
-      "lore"
-    ]
+      "description": "Items uuw Guawdian haz acquiwed ovew theiw wifetime",
+      "name": "Cowwections"
+    }
+  },
+  "collections-lore": {
+    "displayProperties": {
+      "description": "Wowe tewws bwoadew stowies fwom da Destiny univewse. Unwock and wead wowe pages by compweting Twiumphs",
+      "name": "Wowe"
+    }
+  },
+  "collections-medals": {
+    "displayProperties": {
+      "description": "Medaws awe eawned thwough feats of gamepway expewtise. See da wist of medaws and how many of each uu've eawned",
+      "name": "Medaws"
+    }
+  },
+  "collections-metrics": {
+    "displayProperties": {
+      "description": "Stat twackews can be appwied to uuw embwem fwom its inspect view. Appwied twackews wiww appeaw on uuw namepwate whenevew visibwe",
+      "name": "Stat Twackews"
+    }
+  },
+  "collections-patterns-catalysts": {
+    "displayProperties": {
+      "description": "Pattewns enabwe da shaping of weapons. Catawysts expand da powew of uuw Exotic weapons. Find them and finish theiw objectives to unwock uuw awsenaw's fuww potentiaw",
+      "name": "Pattewns \u0026 Catawysts"
+    }
   },
   "commendations": {
     "displayProperties": {
       "description": "Cewebwate uuw fiweteam's successes and ૮ ˶ᵔ ᵕ ᵔ˶ ა awawd them tokens of uuw thoughtfuwness"
-    },
-    "keywords": [
-      "commendations",
-      "guardian rank"
-    ]
-  },
-  "compare": {
-    "displayProperties": {
-      "name": "Compawe",
-      "description": "Go head to head with fewwow Guawdians fow vanity"
     }
   },
   "credits": {
     "displayProperties": {
-      "name": "Cwedits",
-      "description": "About da Guawdians who make it possibwe"
+      "description": "About da Guawdians who make it possibwe",
+      "name": "Cwedits"
     }
   },
   "faq": {
     "displayProperties": {
-      "name": "Fwequentwy Asked Questions",
-      "description": "Da fwequentwy asked and easy to answew"
-    },
-    "keywords": [
-      "faq",
-      "help",
-      "shortcuts"
-    ]
+      "description": "Da fwequentwy asked and easy to answew",
+      "name": "Fwequentwy Asked Questions"
+    }
+  },
+  "inspect-equipment": {
+    "displayProperties": {
+      "description": "Aww item attwibutes; stats, pewks, and mods"
+    }
+  },
+  "inspect-lore": {
+    "displayProperties": {
+      "description": "Wead this item's stowy",
+      "name": "Wowe"
+    }
   },
   "journey": {
     "displayProperties": {
-      "name": "Jouwney",
-      "description": "Navigate uuw Guawdian's jouwney fwom New Wight to Pawagon"
-    },
-    "keywords": [
-      "journey",
-      "guardian rank"
-    ]
+      "description": "Navigate uuw Guawdian's jouwney fwom New Wight to Pawagon",
+      "name": "Jouwney"
+    }
   },
   "legend": {
     "displayProperties": {
-      "name": "Wegend",
-      "description": "Wife and death awe *sweats* wiaw's toows. Weave uuw own wie. Dispway this summawy pwoudwy befowe uuw fwiends and foes."
+      "description": "Wife and death awe *sweats* wiaw's toows. Weave uuw own wie. Dispway this summawy pwoudwy befowe uuw fwiends and foes.",
+      "name": "Wegend"
     }
   },
   "maps": {
     "displayProperties": {
       "description": "Intewactive maps chawting checkwists and othew notabwe destinations"
-    },
-    "keywords": [
-      "eggs",
-      "ahamkara bones",
-      "region chests",
-      "lost sectors"
-    ]
+    }
   },
   "privacy": {
     "displayProperties": {
-      "name": "Pwivacy",
-      "description": "Wespecting pewsonaw boundawies"
+      "description": "Wespecting pewsonaw boundawies",
+      "name": "Pwivacy"
     }
   },
   "quests": {
@@ -209,74 +206,80 @@
   "quests-bounties": {
     "displayProperties": {
       "description": "Aww of da sewected Guawdian's bounties"
-    },
-    "keywords": [
-      "bounty"
-    ]
+    }
   },
   "settings": {
     "displayProperties": {
       "description": "Account, theme, wocaw data, item visibiwity, *bwushes* wanguage, devewopew, twoubweshooting"
     }
   },
+  "settings-advanced": {
+    "displayProperties": {
+      "description": "Pewfowmance, debugging, and stowage management. No one haz fun hewe."
+    }
+  },
+  "settings-common": {
+    "displayProperties": {
+      "description": "Destiny pwofiwe, settings synchwonisation, wanguage, item visibiwity, theme, and mowe—these settings affect how uu enjoy *wuns away* Bwaytech."
+    }
+  },
+  "settings-push-notifications": {
+    "displayProperties": {
+      "description": "Contwow how Bwaytech weaches uu when uu'we not using it."
+    }
+  },
   "triumphs": {
     "displayProperties": {
-      "name": "Twiumphs",
-      "description": "Wecowds uuw Guawdian haz achieved thwough theiw twiaws"
-    },
-    "keywords": [
-      "almost complete",
-      "track",
-      "expiring",
-      "seals"
-    ]
+      "description": "Wecowds uuw Guawdian haz achieved thwough theiw twiaws",
+      "name": "Twiumphs"
+    }
+  },
+  "triumphs-active": {
+    "displayProperties": {
+      "description": "View aww active Twiumphs and Seaws",
+      "name": "Active Twiumphs and Seaws"
+    }
+  },
+  "triumphs-event-card": {
+    "displayProperties": {
+      "description": "Compwete wimited-time Event Cawd chawwenges to eawn vawious wewawds and make pwogwess towawd event Seaw compwetion.",
+      "name": "Active Event Cawd"
+    }
+  },
+  "triumphs-legacy": {
+    "displayProperties": {
+      "description": "View a cowwection of wegacy Twiumphs and Seaws",
+      "name": "Wegacy Twiumphs and Seaws"
+    }
+  },
+  "triumphs-transient": {
+    "displayProperties": {
+      "description": "Not aww Twiumphs awe fowevew–compwete these wecowds with hazte ow be wost fowevew in time.",
+      "name": "Twansient Twiumphs"
+    }
   },
   "weeklies": {
     "displayProperties": {
-      "name": "Weekwies",
-      "description": "A Guawdian's guide to weekwy wituaws with tips fow pwestige and twiumph"
-    },
-    "keywords": [
-      "nightfall",
-      "lost sector",
-      "modules"
-    ]
+      "description": "A Guawdian's guide to weekwy wituaws with tips fow pwestige and twiumph",
+      "name": "Weekwies"
+    }
   },
   "weeklies-challenges": {
     "displayProperties": {
-      "name": "Chawwenges",
-      "description": "Aww activity chawwenges"
-    },
-    "keywords": [
-      "weeklies",
-      "challenges",
-      "milestones",
-      "bonuses"
-    ]
+      "description": "Aww activity chawwenges",
+      "name": "Chawwenges"
+    }
   },
   "weeklies-rotations": {
     "displayProperties": {
-      "name": "Wotations",
-      "description": "Scwy da owbits of vawious activities"
-    },
-    "keywords": [
-      "nightfalls",
-      "lost sectors",
-      "rotations",
-      "calendar",
-      "raids",
-      "wellspring",
-      "altars of sorrow",
-      "ascendant challenge"
-    ]
+      "description": "Scwy da owbits of vawious activities",
+      "name": "Wotations"
+    }
   },
   "weeklies-seasonal-challenges": {
     "displayProperties": {
-      "name": "Seasonaw Chawwenges",
-      "description": "Compwete wimited-time chawwenges fow Season wank, Bwight Dust, and othew wewawds"
-    },
-    "keywords": [
-      "seasonal challenges"
-    ]
+      "description": "Compwete wimited-time chawwenges fow Season wank, Bwight Dust, and othew wewawds",
+      "name": "Seasonaw Chawwenges"
+    }
   }
 }

--- a/en-OwO/BraytechMapsDefinition.json
+++ b/en-OwO/BraytechMapsDefinition.json
@@ -1,8 +1,8 @@
 {
   "1": {
     "displayProperties": {
-      "name": "Da Confwuence West",
-      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies."
+      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies.",
+      "name": "Da Confwuence West"
     }
   },
   "10": {
@@ -72,14 +72,14 @@
   },
   "12": {
     "displayProperties": {
-      "name": "Agonawch Abyss",
-      "description": "Weach da bottom and ewiminate da Taken Wizawds.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._"
+      "description": "Weach da bottom and ewiminate da Taken Wizawds.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._",
+      "name": "Agonawch Abyss"
     }
   },
   "13": {
     "displayProperties": {
-      "name": "Agonawch Abyss",
-      "description": "A powtaw to da **Ascendant Pwane**."
+      "description": "A powtaw to da **Ascendant Pwane**.",
+      "name": "Agonawch Abyss"
     }
   },
   "1387596458": {
@@ -89,38 +89,38 @@
   },
   "14": {
     "displayProperties": {
-      "name": "Cimmewian Gawwison",
-      "description": "This chawwenge cuwminates in a fight between da Guawdian, a Hive Knight, and thwee Hive Shwiekews, on a spacious pwatfowm with vawious covew fwom enemy fiwe.\n\n_Accept this chawwenge, wawk *boops uuw nose* between wowwds, and undo what haz been done._"
+      "description": "This chawwenge cuwminates in a fight between da Guawdian, a Hive Knight, and thwee Hive Shwiekews, on a spacious pwatfowm with vawious covew fwom enemy fiwe.\n\n_Accept this chawwenge, wawk *boops uuw nose* between wowwds, and undo what haz been done._",
+      "name": "Cimmewian Gawwison"
     }
   },
   "15": {
     "displayProperties": {
-      "name": "Cimmewian Gawwison",
-      "description": "A powtaw to da **Ascendant Pwane**."
+      "description": "A powtaw to da **Ascendant Pwane**.",
+      "name": "Cimmewian Gawwison"
     }
   },
   "16": {
     "displayProperties": {
-      "name": "Nightmawe of Xowtaw, Swown of Cwota",
-      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**."
+      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**.",
+      "name": "Nightmawe of Xowtaw, Swown of Cwota"
     }
   },
   "17": {
     "displayProperties": {
-      "name": "Nightmawe of Howkis, Feaw of Mithwax",
-      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**."
+      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**.",
+      "name": "Nightmawe of Howkis, Feaw of Mithwax"
     }
   },
   "18": {
     "displayProperties": {
-      "name": "Nightmawe of Jaxx, Cwaw of *boops uuw nose* Xivu Awath",
-      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**."
+      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**.",
+      "name": "Nightmawe of Jaxx, Cwaw of *boops uuw nose* Xivu Awath"
     }
   },
   "19": {
     "displayProperties": {
-      "name": "Fawwen Counciw",
-      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**."
+      "description": "Defeat this Nightmawe to pwogwess wecowd **Wandewing Nightmawes**.",
+      "name": "Fawwen Counciw"
     }
   },
   "1903309704": {
@@ -130,8 +130,8 @@
   },
   "2": {
     "displayProperties": {
-      "name": "Da Confwuence East",
-      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies."
+      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies.",
+      "name": "Da Confwuence East"
     }
   },
   "2000000000": {
@@ -196,8 +196,8 @@
   },
   "2000000012": {
     "displayProperties": {
-      "name": "Find Towand",
-      "description": "Seek out Towand to heaw his wuminations about da Moon."
+      "description": "Seek out Towand to heaw his wuminations about da Moon.",
+      "name": "Find Towand"
     }
   },
   "2000000014": {
@@ -212,14 +212,14 @@
   },
   "2000000016": {
     "displayProperties": {
-      "name": "Hunt da Nightmawe of Tawgoth, Souw Smashew",
-      "description": "Go to da Gatehouse and take out da Nightmawe of Tawgoth, Souw Smashew."
+      "description": "Go to da Gatehouse and take out da Nightmawe of Tawgoth, Souw Smashew.",
+      "name": "Hunt da Nightmawe of Tawgoth, Souw Smashew"
     }
   },
   "2000000017": {
     "displayProperties": {
-      "name": "Find Towand",
-      "description": "Seek out Towand to heaw his wuminations about da Moon."
+      "description": "Seek out Towand to heaw his wuminations about da Moon.",
+      "name": "Find Towand"
     }
   },
   "2000000018": {
@@ -234,8 +234,8 @@
   },
   "2000000020": {
     "displayProperties": {
-      "name": "Find Towand",
-      "description": "Seek out Towand to heaw his wuminations about da Moon."
+      "description": "Seek out Towand to heaw his wuminations about da Moon.",
+      "name": "Find Towand"
     }
   },
   "2000000021": {
@@ -250,8 +250,8 @@
   },
   "2000000024": {
     "displayProperties": {
-      "name": "Find Towand",
-      "description": "Seek out Towand to heaw his wuminations about da Moon."
+      "description": "Seek out Towand to heaw his wuminations about da Moon.",
+      "name": "Find Towand"
     }
   },
   "2000000026": {
@@ -591,50 +591,50 @@
   },
   "2000000103": {
     "displayProperties": {
-      "name": "Chwonicwew of Histowy",
-      "description": "Wetwieve a thwee-dimensionaw scan of a pwe-cowwapse scuwptuwe in Maevic Squawe."
+      "description": "Wetwieve a thwee-dimensionaw scan of a pwe-cowwapse scuwptuwe in Maevic Squawe.",
+      "name": "Chwonicwew of Histowy"
     }
   },
   "2000000104": {
     "displayProperties": {
-      "name": "Da Scavenge Beast",
-      "description": "Fawwen scavenging cwews continue to pwesent a pwobwem in Maevic Squawe. Ewiminate theiw weadew to sowve da pwobwem."
+      "description": "Fawwen scavenging cwews continue to pwesent a pwobwem in Maevic Squawe. Ewiminate theiw weadew to sowve da pwobwem.",
+      "name": "Da Scavenge Beast"
     }
   },
   "2000000105": {
     "displayProperties": {
-      "name": "Mining Opewations",
-      "description": "Descend into da mines and seawch fow any stiww-functioning Gowden Age technowogy."
+      "description": "Descend into da mines and seawch fow any stiww-functioning Gowden Age technowogy.",
+      "name": "Mining Opewations"
     }
   },
   "2000000106": {
     "displayProperties": {
-      "name": "Those Don't Bewong to Uu",
-      "description": "Defeat Fawwen in Twostwand and cowwect da Fowgotten Jouwnaws they dwop."
+      "description": "Defeat Fawwen in Twostwand and cowwect da Fowgotten Jouwnaws they dwop.",
+      "name": "Those Don't Bewong to Uu"
     }
   },
   "2000000107": {
     "displayProperties": {
-      "name": "Uwban Fwight",
-      "description": "Da Fawwen awe mowe famiwiaw with tewwain in da Outskits than humanity is. Shift that bawance."
+      "description": "Da Fawwen awe mowe famiwiaw with tewwain in da Outskits than humanity is. Shift that bawance.",
+      "name": "Uwban Fwight"
     }
   },
   "2000000108": {
     "displayProperties": {
-      "name": "Cweaning Up da Stweets",
-      "description": "Ewiminate Dwegs in Twostwand and wecovew theiw Dwained Ethew Tanks."
+      "description": "Ewiminate Dwegs in Twostwand and wecovew theiw Dwained Ethew Tanks.",
+      "name": "Cweaning Up da Stweets"
     }
   },
   "2000000109": {
     "displayProperties": {
-      "name": "Deep, Dawk, and Down",
-      "description": "A Fawwen Sewvitow is stwipping da cavewn wawws fow minewaws. Put a stop to it."
+      "description": "A Fawwen Sewvitow is stwipping da cavewn wawws fow minewaws. Put a stop to it.",
+      "name": "Deep, Dawk, and Down"
     }
   },
   "2000000110": {
     "displayProperties": {
-      "name": "Not in My Backyawd",
-      "description": "Defeat enemies in da stweets and buiwdings of this wuined town."
+      "description": "Defeat enemies in da stweets and buiwdings of this wuined town.",
+      "name": "Not in My Backyawd"
     }
   },
   "2000000112": {
@@ -839,170 +839,170 @@
   },
   "2000000163": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000164": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000165": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000168": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000169": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000170": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000176": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000177": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000180": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000181": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000186": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000187": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000188": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000189": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000190": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000191": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000192": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000193": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000195": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000196": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000197": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000198": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000199": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000200": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000201": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000202": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000203": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000204": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000215": {
@@ -1017,136 +1017,136 @@
   },
   "2000000231": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000232": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000233": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000234": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000235": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000236": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000237": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000238": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000239": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000240": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000241": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000242": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000243": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000244": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000245": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000246": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000247": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000248": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000249": {
     "displayProperties": {
-      "name": "Wandom",
-      "description": "This beacon can weway vawious *bwushes* objectives."
+      "description": "This beacon can weway vawious *bwushes* objectives.",
+      "name": "Wandom"
     }
   },
   "2000000251": {
     "displayProperties": {
-      "name": "Awwuwing Cuwtain Executionew",
-      "description": "Defeat da Wucent Executionew gawwisoned in Awwuwing Cuwtain to pwogwess wecowd **Ascended Bounty Huntew**."
+      "description": "Defeat da Wucent Executionew gawwisoned in Awwuwing Cuwtain to pwogwess wecowd **Ascended Bounty Huntew**.",
+      "name": "Awwuwing Cuwtain Executionew"
     },
     "itemTypeDisplayName": "Wucent Executionew"
   },
   "2000000252": {
     "displayProperties": {
-      "name": "Queen's Baiwey Executionew",
-      "description": "Defeat da Wucent Executionew gawwisoned in Queen's Baiwey to pwogwess wecowd **Ascended Bounty Huntew**."
+      "description": "Defeat da Wucent Executionew gawwisoned in Queen's Baiwey to pwogwess wecowd **Ascended Bounty Huntew**.",
+      "name": "Queen's Baiwey Executionew"
     },
     "itemTypeDisplayName": "Wucent Executionew"
   },
   "2000000253": {
     "displayProperties": {
-      "name": "Witch's Echo Executionew",
-      "description": "Defeat da Wucent Executionew gawwisoned in Witch's Echo to pwogwess wecowd **Ascended Bounty Huntew**."
+      "description": "Defeat da Wucent Executionew gawwisoned in Witch's Echo to pwogwess wecowd **Ascended Bounty Huntew**.",
+      "name": "Witch's Echo Executionew"
     },
     "itemTypeDisplayName": "Wucent Executionew"
   },
@@ -1192,8 +1192,8 @@
   },
   "278": {
     "displayProperties": {
-      "name": "Queen's Couwt",
-      "description": "A powtaw to **Queen's Couwt**, Mawa Sov's thwone wowwd."
+      "description": "A powtaw to **Queen's Couwt**, Mawa Sov's thwone wowwd.",
+      "name": "Queen's Couwt"
     }
   },
   "2809244994": {
@@ -1208,8 +1208,8 @@
   },
   "3": {
     "displayProperties": {
-      "name": "Da Confwuence South",
-      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies."
+      "description": "A powtaw to **Da Confwuence**, powewed by pawacasuaw enewgies.",
+      "name": "Da Confwuence South"
     }
   },
   "3307732497": {
@@ -1264,8 +1264,8 @@
   },
   "4": {
     "displayProperties": {
-      "name": "Ouwobowea",
-      "description": "Destwoy aww bwights then wetuwn to da foyew to shattew da pweviouswy-immune Void cwystaws.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._"
+      "description": "Destwoy aww bwights then wetuwn to da foyew to shattew da pweviouswy-immune Void cwystaws.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._",
+      "name": "Ouwobowea"
     }
   },
   "4006123814": {
@@ -1330,8 +1330,8 @@
   },
   "5": {
     "displayProperties": {
-      "name": "Ouwobowea",
-      "description": "A powtaw to da **Ascendant Pwane**."
+      "description": "A powtaw to da **Ascendant Pwane**.",
+      "name": "Ouwobowea"
     }
   },
   "576743835": {
@@ -1346,56 +1346,56 @@
   },
   "596": {
     "displayProperties": {
-      "name": "Sawt Mines Cwiffs",
-      "description": "A twansmat pwatfowm connected to da top of da **Sawt Mines** cwiffs, powewed by juwy-wigged **Fawwen** pawts."
+      "description": "A twansmat pwatfowm connected to da top of da **Sawt Mines** cwiffs, powewed by juwy-wigged **Fawwen** pawts.",
+      "name": "Sawt Mines Cwiffs"
     }
   },
   "6": {
     "displayProperties": {
-      "name": "Fowfeit Shwine",
-      "description": "Subdue da majow bwight by depositing aww thwee chawges beneath. Ewiminate da Hive Knights.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._"
+      "description": "Subdue da majow bwight by depositing aww thwee chawges beneath. Ewiminate da Hive Knights.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._",
+      "name": "Fowfeit Shwine"
     }
   },
   "607": {
     "displayProperties": {
-      "name": "Esi Tewminaw–Iwkawwa Compwex",
-      "description": "A wesonance-powewed wift to **Iwkawwa Compwex**."
+      "description": "A wesonance-powewed wift to **Iwkawwa Compwex**.",
+      "name": "Esi Tewminaw–Iwkawwa Compwex"
     }
   },
   "608": {
     "displayProperties": {
-      "name": "Iwkawwa Compwex–Esi Tewminaw",
-      "description": "A wesonance-powewed wift to **Esi Tewminaw**."
+      "description": "A wesonance-powewed wift to **Esi Tewminaw**.",
+      "name": "Iwkawwa Compwex–Esi Tewminaw"
     }
   },
   "609": {
     "displayProperties": {
-      "name": "Typhon Impewatow: Deep",
-      "description": "A wesonance-powewed wift."
+      "description": "A wesonance-powewed wift.",
+      "name": "Typhon Impewatow: Deep"
     }
   },
   "610": {
     "displayProperties": {
-      "name": "Typhon Impewatow",
-      "description": "A wesonance-powewed wift."
+      "description": "A wesonance-powewed wift.",
+      "name": "Typhon Impewatow"
     }
   },
   "611": {
     "displayProperties": {
-      "name": "Tempwe of da Wwathfuw",
-      "description": "A wesonance-powewed wift."
+      "description": "A wesonance-powewed wift.",
+      "name": "Tempwe of da Wwathfuw"
     }
   },
   "612": {
     "displayProperties": {
-      "name": "Tempwe of da Wwathfuw: Deep",
-      "description": "A wesonance-powewed wift."
+      "description": "A wesonance-powewed wift.",
+      "name": "Tempwe of da Wwathfuw: Deep"
     }
   },
   "7": {
     "displayProperties": {
-      "name": "Fowfeit Shwine",
-      "description": "A powtaw to da **Ascendant Pwane**."
+      "description": "A powtaw to da **Ascendant Pwane**.",
+      "name": "Fowfeit Shwine"
     }
   },
   "703052847": {
@@ -1405,8 +1405,8 @@
   },
   "8": {
     "displayProperties": {
-      "name": "Shattewed Wuins",
-      "description": "Cwimb da wuins and ewiminate da Taken Phawanx.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._"
+      "description": "Cwimb da wuins and ewiminate da Taken Phawanx.\n\n_Accept this chawwenge, wawk between wowwds, and undo what haz been done._",
+      "name": "Shattewed Wuins"
     }
   },
   "823939877": {
@@ -1416,8 +1416,8 @@
   },
   "9": {
     "displayProperties": {
-      "name": "Shattewed Wuins",
-      "description": "A powtaw to da **Ascendant Pwane**."
+      "description": "A powtaw to da **Ascendant Pwane**.",
+      "name": "Shattewed Wuins"
     }
   }
 }

--- a/en-OwO/BraytechRotationDefinition.json
+++ b/en-OwO/BraytechRotationDefinition.json
@@ -7,7 +7,34 @@
   "2": {
     "displayProperties": {
       "name": "Ascendant Chawwenge"
-    }
+    },
+    "rotation": [
+      {
+        "displayProperties": {
+          "name": "Ouwobowea"
+        }
+      },
+      {
+        "displayProperties": {
+          "name": "Fowfeit Shwine"
+        }
+      },
+      {
+        "displayProperties": {
+          "name": "Shattewed Wuins"
+        }
+      },
+      {
+        "displayProperties": {
+          "name": "Agonawch Abyss"
+        }
+      },
+      {
+        "displayProperties": {
+          "name": "Cimmewian Gawwison"
+        }
+      }
+    ]
   },
   "3": {
     "displayProperties": {

--- a/en-OwO/DestinyActivityDefinition.json
+++ b/en-OwO/DestinyActivityDefinition.json
@@ -1,12 +1,12 @@
 {
   "0": {
     "displayProperties": {
-      "name": "Cwassified",
-      "description": "Keep it cwean."
+      "description": "Keep it cwean.",
+      "name": "Cwassified"
     },
     "originalDisplayProperties": {
-      "name": "Cwassified",
-      "description": "Keep it cwean."
+      "description": "Keep it cwean.",
+      "name": "Cwassified"
     }
   },
   "1214397515": {

--- a/en-OwO/DestinyActivityModeDefinition.json
+++ b/en-OwO/DestinyActivityModeDefinition.json
@@ -1,14 +1,14 @@
 {
   "103143560": {
     "displayProperties": {
-      "name": "Wost *sweats* Sectows",
-      "description": "Advanced scouts haz mawked sectows of stwategic intewest ahead of uu.\n\nInspect them fow thweats and wawe geaw."
+      "description": "Advanced scouts haz mawked sectows of stwategic intewest ahead of uu.\n\nInspect them fow thweats and wawe equipment.",
+      "name": "Wost *sweats* Sectows"
     }
   },
   "11647605040": {
     "displayProperties": {
-      "name": "Aww Cwucibwe",
-      "description": "Did uu thwow enough gwenades? UwU"
+      "description": "Did uu thwow enough gwenades? UwU",
+      "name": "Aww Cwucibwe"
     }
   },
   "1264443021": {
@@ -53,8 +53,8 @@
   },
   "20434039890": {
     "displayProperties": {
-      "name": "Waids",
-      "description": "Fowm a fiweteam of six god-kiwwews and bwave da stwange and powewfuw weawms of ouw enemies."
+      "description": "Fowm a fiweteam of six god-kiwwews and bwave da stwange and powewfuw weawms of ouw enemies.",
+      "name": "Waids"
     }
   },
   "2239249083": {
@@ -84,8 +84,8 @@
   },
   "31990984800": {
     "displayProperties": {
-      "name": "Momentum Contwow",
-      "description": "Fight fow Vawow by captuwing zones and defeating opponents. Aww weapons awe mowe wethaw, abiwities wepwenish onwy on kiwws, and twackew is disabwed."
+      "description": "Fight fow Vawow by captuwing zones and defeating opponents. Aww weapons awe mowe wethaw, abiwities wepwenish onwy on kiwws, and twackew is disabwed.",
+      "name": "Momentum Contwow"
     }
   },
   "3484731833": {
@@ -100,14 +100,14 @@
   },
   "4110605575": {
     "displayProperties": {
-      "name": "*boops uuw nose* Vanguawd Stwikes",
-      "description": "Doing da Vanguawd's diwty wowk and keeping da fwontiew undew contwow."
+      "description": "Doing da Vanguawd's diwty wowk and keeping da fwontiew undew contwow.",
+      "name": "*boops uuw nose* Vanguawd Stwikes"
     }
   },
   "547513715": {
     "displayProperties": {
-      "name": "Nightfaww: Da Owdeaw",
-      "description": "Da Vanguawd authowizes Nightfaww stwikes to take down da gweatest thweats faced by da City.\n\nWeview Guawdian pewfowmance and pwepawe fow da next thweat."
+      "description": "Da Vanguawd authowizes Nightfaww stwikes to take down da gweatest thweats faced by da City.\n\nWeview Guawdian pewfowmance and pwepawe fow da next thweat.",
+      "name": "Nightfaww: Da Owdeaw"
     }
   },
   "608898761": {
@@ -117,8 +117,8 @@
   },
   "748895195": {
     "displayProperties": {
-      "name": "Aww Activities",
-      "description": "Post game cawnage wepowts fow aww activity modes: da cuwmination of aww of uuw effowts."
+      "description": "Post game cawnage wepowts fow aww activity modes: da cuwmination of aww of uuw effowts.",
+      "name": "Aww Activities"
     }
   },
   "9924991580": {

--- a/en-OwO/DestinyActivityModifierDefinition.json
+++ b/en-OwO/DestinyActivityModifierDefinition.json
@@ -1,8 +1,8 @@
 {
   "138641527": {
     "displayProperties": {
-      "name": "Cwossfiwe",
-      "description": "$$UNKNOWN$$ [[mode:weceive]]\n\n\"Await instwuction...\""
+      "description": "Shoot acwoss da gap to (・`ω´・) twiggew teammates' swingshot cwuxes. Onwy use swingshots to cwoss da gap.",
+      "name": "Cwossfiwe"
     }
   },
   "1498263100": {
@@ -17,8 +17,8 @@
   },
   "1616571513": {
     "displayProperties": {
-      "name": "Aww Hands",
-      "description": "$$UNKNOWN$$ [[mode:weceive]]\n\n\"Await instwuction...\""
+      "description": "$$UNKNOWN$$ [[mode:weceive]]\n\n\"Await instwuction...\"",
+      "name": "Aww Hands"
     }
   },
   "1741733430": {
@@ -38,8 +38,8 @@
   },
   "2070303007": {
     "displayProperties": {
-      "name": "Cosmic Equiwibwium",
-      "description": "$$UNKNOWN$$ [[mode:weceive]]\n\n\"Await instwuction...\""
+      "description": "Move aww tewwafowmed (wight) pwanets wight and wesonant (dawk) pwanets weft. Wequiwes two Pwanetawy Shift phazes pew pwate.",
+      "name": "Cosmic Equiwibwium"
     }
   },
   "2098788044": {
@@ -64,8 +64,8 @@
   },
   "25589576690": {
     "displayProperties": {
-      "name": "Sowaw Shiewds",
-      "description": "This activity haz Sowaw shiewds"
+      "description": "Uu wiww face combatants with [Sowaw] Sowaw shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "2626004713": {
@@ -115,8 +115,8 @@
   },
   "32153845200": {
     "displayProperties": {
-      "name": "Awc Shiewds",
-      "description": "This activity haz Awc shiewds"
+      "description": "Uu wiww face combatants with [Awc] Awc shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "3361897360": {
@@ -126,8 +126,8 @@
   },
   "33620748140": {
     "displayProperties": {
-      "name": "Void Shiewds",
-      "description": "This activity haz Void shiewds"
+      "description": "Uu wiww face combatants with [Void] Void shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "3425521520": {
@@ -137,26 +137,26 @@
   },
   "34300000001": {
     "displayProperties": {
-      "name": "Sowaw and Awc Shiewds",
-      "description": "This activity haz Sowaw and Awc shiewds"
+      "description": "Uu wiww face combatants with [Sowaw] Sowaw and [Awc] Awc shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "34300000002": {
     "displayProperties": {
-      "name": "Sowaw and Void Shiewds",
-      "description": "This activity haz Sowaw and Void shiewds"
+      "description": "Uu wiww face combatants with [Sowaw] Sowaw and [Void] Void shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "34300000003": {
     "displayProperties": {
-      "name": "Awc and Void Shiewds",
-      "description": "This activity haz Awc and Void shiewds"
+      "description": "Uu wiww face combatants with [Awc] Awc and [Void] Void shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "34300000004": {
     "displayProperties": {
-      "name": "Sowaw, Awc, and Void Shiewds",
-      "description": "This activity haz Sowaw, Awc, and Void shiewds"
+      "description": "Uu wiww face combatants with [Sowaw] Sowaw, [Awc] Awc, and [Void] Void shiewds.",
+      "name": "Shiewded Foes"
     }
   },
   "3577304467": {
@@ -191,8 +191,8 @@
   },
   "766975360": {
     "displayProperties": {
-      "name": "Iwwuminated Towment",
-      "description": "Guawdians may kiww **Towmentews** onwy when affected by **Fiewd of Wight**."
+      "description": "Guawdians may kiww **Towmentews** onwy when affected by **Fiewd of Wight**.",
+      "name": "Iwwuminated Towment"
     }
   },
   "787678752": {

--- a/en-OwO/DestinyChecklistDefinition.json
+++ b/en-OwO/DestinyChecklistDefinition.json
@@ -4,8 +4,8 @@
       "name": "Stasis-Seawed Chests"
     },
     "entry": {
-      "prefix": "Awtifact",
-      "name": "Stasis-Seawed Chest"
+      "name": "Stasis-Seawed Chest",
+      "prefix": "Awtifact"
     }
   },
   "1000002000": {
@@ -46,8 +46,8 @@
       "name": "Entwopic Shawds"
     },
     "entry": {
-      "prefix": "Shawd",
-      "name": "Entwopic Shawd"
+      "name": "Entwopic Shawd",
+      "prefix": "Shawd"
     },
     "progressDescription": "Owdew westowed"
   },
@@ -83,8 +83,8 @@
       "name": "Dawkness Wifts"
     },
     "entry": {
-      "prefix": "Wift",
-      "name": "Dawkness Wift"
+      "name": "Dawkness Wift",
+      "prefix": "Wift"
     },
     "progressDescription": "Wifts seawed"
   },
@@ -135,8 +135,8 @@
       "name": "*boops uuw nose* Penguin Souveniws"
     },
     "entry": {
-      "prefix": "Souveniw",
-      "name": "*wuns away* Penguin Souveniw"
+      "name": "*wuns away* Penguin Souveniw",
+      "prefix": "Souveniw"
     },
     "progressDescription": "Souveniws cowwected"
   }

--- a/en-OwO/DestinyCollectibleDefinition.json
+++ b/en-OwO/DestinyCollectibleDefinition.json
@@ -20,6 +20,11 @@
   "1988948484": {
     "sourceString": "Souwce: Eawned by compweting da \"Devine Fwagmentation\" exotic quest."
   },
+  "2056946089": {
+    "displayProperties": {
+      "description": "An embwem designed as twibute to a community membew past, Sewaphim Cwypto. Uu can wead mowe about theiw wegend in [da TWAB of Septembew 15, 2022](https://www.bungie.net/en/Explore/Detail/News/51779)."
+    }
+  },
   "2172413746": {
     "sourceString": "Compwete da \"Vauwt of Gwass\" waid and aww encountew chawwenges within da fiwst 24 houws of wewease."
   },

--- a/en-OwO/DestinyCollectibleDefinitionColloquial.json
+++ b/en-OwO/DestinyCollectibleDefinitionColloquial.json
@@ -1,0 +1,22 @@
+{
+  "1660030044": {
+    "displayProperties": {
+      "name": "Wegaw No-Skiww Hacking"
+    }
+  },
+  "199171385": {
+    "displayProperties": {
+      "name": "997 Voices (Pweowned)"
+    }
+  },
+  "3875807583": {
+    "displayProperties": {
+      "name": "Scweam of da Whawe"
+    }
+  },
+  "720772515": {
+    "displayProperties": {
+      "name": "Nothing Manacwes (Dysfunctionaw)"
+    }
+  }
+}

--- a/en-OwO/DestinyDamageTypeDefinition.json
+++ b/en-OwO/DestinyDamageTypeDefinition.json
@@ -13,5 +13,8 @@
   },
   "3454344768": {
     "itemTypeDisplayName": "Enewgy Type"
+  },
+  "3949783978": {
+    "itemTypeDisplayName": "Enewgy Type"
   }
 }

--- a/en-OwO/DestinyHistoricalStatsDefinition.json
+++ b/en-OwO/DestinyHistoricalStatsDefinition.json
@@ -117,8 +117,8 @@
     "statDescription": "Stop an opponent's Supew with uuw Supew."
   },
   "activitiesCleared": {
-    "statName": "Cweawed",
-    "statDescription": "Totaw activities cweawed successfuwwy. Hopefuwwy, Guawdian, this vawue is gweatew than hawf of activities entewed! OwO"
+    "statDescription": "Totaw activities cweawed successfuwwy. Hopefuwwy, Guawdian, this vawue is gweatew than hawf of activities entewed! OwO",
+    "statName": "Cweawed"
   },
   "activitiesEntered": {
     "statName": "Entewed"
@@ -130,12 +130,12 @@
     "statName": "Bwockew Kiwws"
   },
   "currentCompetitiveRating": {
-    "statName": "Cuwwent Competitive Wating",
-    "statDescription": "Pwayew's cuwwent Competitive Division wating."
+    "statDescription": "Pwayew's cuwwent Competitive Division wating.",
+    "statName": "Cuwwent Competitive Wating"
   },
   "currentEloRating": {
-    "statName": "Cuwwent Ewo Wating",
-    "statDescription": "Pwayew's cuwwent Ewo wating.\n\nEwo watings fwom a thiwd-pawty web site, _Destiny Twackew_. _Destiny Twackew_ pwovides Ewo watings fow aww Destiny pwayews who pawticipate in _Cwucibwe_ and _Gambit_ activities."
+    "statDescription": "Pwayew's cuwwent Ewo wating.\n\nEwo watings fwom a thiwd-pawty web site, _Destiny Twackew_. _Destiny Twackew_ pwovides Ewo watings fow aww Destiny pwayews who pawticipate in _Cwucibwe_ and _Gambit_ activities.",
+    "statName": "Cuwwent Ewo Wating"
   },
   "flawless": {
     "statName": "Fwawwess"

--- a/en-OwO/DestinyInventoryItemDefinition.json
+++ b/en-OwO/DestinyInventoryItemDefinition.json
@@ -1,8 +1,8 @@
 {
   "0": {
     "displayProperties": {
-      "name": "Cwassified",
-      "description": "Keep it cwean."
+      "description": "Keep it cwean.",
+      "name": "Cwassified"
     },
     "itemTypeDisplayName": "Insufficient Cweawance"
   },
@@ -15,6 +15,12 @@
   "1190250163": {
     "displayProperties": {
       "description": "Synthcowd matewiaw which can be convewted to Synthweave using da Woom."
+    }
+  },
+  "1541696845": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da *boops uuw nose* \"Cowwective Obwigation\" exotic puwse wifwe fwom da \"Vow of da Discipwe\" waid.",
+      "name": "Incweased \"Cowwective Obwigation\" dwop wate"
     }
   },
   "1711513650": {
@@ -34,8 +40,14 @@
   },
   "1950177353": {
     "displayProperties": {
-      "name": "Incweased \"Heawtshadow\" dwop wate",
-      "description": "Incweases da dwop wate of da \"Heawtshadow\" exotic swowd fwom da \"Duawity\" dungeon."
+      "description": "Incweases da initiaw dwop wate of da \"Heawtshadow\" exotic swowd fwom da \"Duawity\" dungeon.",
+      "name": "Incweased \"Heawtshadow\" dwop wate"
+    }
+  },
+  "2126433420": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da \"Da Navigatow\" exotic twace wifwe fwom da \"Ghosts of da Deep\" dungeon.",
+      "name": "Incweased \"Da Navigatow\" dwop wate"
     }
   },
   "2174060729": {
@@ -50,19 +62,31 @@
   },
   "23239861010": {
     "displayProperties": {
-      "name": "Empty Mastewwowk Socket",
-      "description": "No mastewwowk cuwwentwy sewected."
+      "description": "No mastewwowk cuwwentwy sewected.",
+      "name": "Empty Mastewwowk Socket"
     }
   },
   "2467253899": {
     "displayProperties": {
-      "name": "Incweased \"Conditionaw Finawity\" dwop wate",
-      "description": "Incweases da dwop wate of da \"Conditionaw Finawity\" exotic shotgun fwom da \"Woot of Nightmawes\" waid."
+      "description": "Gweatwy incweases da initiaw dwop wate of da \"Conditionaw Finawity\" exotic shotgun fwom da \"Woot of Nightmawes\" waid.",
+      "name": "Incweased \"Conditionaw Finawity\" dwop wate"
     }
   },
   "2497395625": {
     "displayProperties": {
       "description": "Matewiaw used in weapon shaping, wequiwed to adjust intwinsic pwugs.\n\nPwimawiwy obtained by dismantwing Wegendawy weapons, but can awso be wewawded fow compweting activities."
+    }
+  },
+  "2643364263": {
+    "displayProperties": {
+      "description": "An engwam with wemawkabwe encoding mawkews. A Cwyptawch wouwd be thwiwwed to decode this to weveaw its twue natuwe."
+    },
+    "itemTypeDisplayName": "Engwam"
+  },
+  "2902936983": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da \"Touch of Mawice\" exotic scout wifwe fwom da \"King's Faww\" waid.",
+      "name": "Incweased \"Touch of Mawice\" dwop wate"
     }
   },
   "304443327": {
@@ -72,8 +96,8 @@
   },
   "3224646387": {
     "displayProperties": {
-      "name": "Incweased \"Hiewawchy of Needs\" dwop wate",
-      "description": "Incweases da dwop wate of da \"Hiewawchy of Needs\" exotic bow fwom da \"Spiwe of da Watchew\" dungeon."
+      "description": "Incweases da initiaw dwop wate of da \"Hiewawchy of Needs\" exotic bow fwom da \"Spiwe of da Watchew\" dungeon.",
+      "name": "Incweased \"Hiewawchy of Needs\" dwop wate"
     }
   },
   "3348653032": {
@@ -102,6 +126,12 @@
       "description": "Incweases uuw Guawdian's expewience substantiawwy."
     }
   },
+  "700251940": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da \"Eyes of Tomowwow\" exotic wocket waunchew fwom da \"Deep Stone Cwypt\" waid.",
+      "name": "Incweased \"Eyes of Tomowwow\" dwop wate"
+    }
+  },
   "73143230": {
     "displayProperties": {
       "description": "An engwam with compwex mawkews.\nContains a wandom Pinnacwe Wegendawy weapon ow awmow piece."
@@ -115,8 +145,20 @@
   },
   "734180536": {
     "displayProperties": {
-      "name": "Incweased \"Conditionaw Finawity\" dwop wate",
-      "description": "Incweases da dwop wate of da \"Conditionaw Finawity\" exotic shotgun fwom da \"Woot of Nightmawes\" waid."
+      "description": "Incweases da initiaw dwop wate of da \"Conditionaw Finawity\" exotic shotgun fwom da \"Woot of Nightmawes\" waid.",
+      "name": "Incweased \"Conditionaw Finawity\" dwop wate"
+    }
+  },
+  "901060145": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da \"Vex Mythocwast\" exotic fusion wifwe fwom da \"Vauwt of Gwass\" waid.",
+      "name": "Incweased \"Vex Mythocwast\" dwop wate"
+    }
+  },
+  "951399115": {
+    "displayProperties": {
+      "description": "Incweases da initiaw dwop wate of da \"One Thousand Voices\" exotic fusion wifwe fwom da \"Wast Wish\" waid.",
+      "name": "Incweased \"One Thousand Voices\" *boops uuw nose* dwop wate"
     }
   }
 }

--- a/en-OwO/DestinyInventoryItemDefinitionColloquial.json
+++ b/en-OwO/DestinyInventoryItemDefinitionColloquial.json
@@ -4,9 +4,19 @@
       "name": "Scweam of da Whawe"
     }
   },
+  "2069224589": {
+    "displayProperties": {
+      "name": "997 Voices (Pweowned)"
+    }
+  },
   "2849050827": {
     "displayProperties": {
-      "name": "Gwape Eatew"
+      "name": "Gwape Eatew (Expiwed)"
+    }
+  },
+  "300502917": {
+    "displayProperties": {
+      "name": "Nothing Manacwes (Dysfunctionaw)"
     }
   },
   "353704689": {
@@ -21,9 +31,14 @@
   },
   "73143230": {
     "displayProperties": {
-      "description": "Da good shit, bwuh.",
+      "description": "Da good shit, bwah.",
       "name": "*wuns away* Pinny Geaw"
     },
     "itemTypeDisplayName": "Engwam"
+  },
+  "814876684": {
+    "displayProperties": {
+      "name": "Wegaw No-Skiww Hacking"
+    }
   }
 }

--- a/en-OwO/DestinyObjectiveDefinition.json
+++ b/en-OwO/DestinyObjectiveDefinition.json
@@ -1,4 +1,10 @@
 {
+  "1064977327": {
+    "displayProperties": {
+      "description": "Deputy Commandew Swoane spotted a Wucent Hive *boops uuw nose* command ship entewing Titan's atmosphewe. Showtwy aftew its awwivaw, da ship dove into da moon's methane sea and anomawous enewgy weadings spiked at da New Pacific Awcowogy. Da deputy commandew haz cawwed on uu to investigate."
+    },
+    "progressDescription": "\"Ghost of da Deep\" dungeon compweted"
+  },
   "1166527222": {
     "progressDescription": "\"Defiant Battwegwounds\" activities compweted"
   },
@@ -23,29 +29,41 @@
   "1612424695": {
     "progressDescription": "Nightfaww scowe accwued"
   },
+  "1685423788": {
+    "progressDescription": "\"Sawvage\" activities compweted"
+  },
   "1687723774": {
     "progressDescription": "\"Defiant Battwegwounds\" activities compweted"
   },
   "1734176373": {
     "progressDescription": "Gambit matches compweted"
   },
+  "1863972407": {
+    "displayProperties": {
+      "description": "Step fowwawd, Discipwe-Swayew."
+    },
+    "progressDescription": "\"Vow of da Discipwe\" wotatow waid compweted"
+  },
   "1878970132": {
-    "progressDescription": "Iwon Bannew matches compweted as [Stasis] Stasis ow *bwushes* [Void] Void subcwasses"
+    "progressDescription": "Iwon Bannew matches compweted as [Awc] Awc, ow [Void] Void, ow [Stwand] Stwand subcwasses"
   },
   "1948254616": {
     "progressDescription": "\"Dawes of Etewnity\" activities compweted"
   },
   "2039792527": {
+    "displayProperties": {
+      "description": "Entew da weawm of da Nine, suwvive, and be wewawded with knowwedge, and pewhaps mowe."
+    },
     "progressDescription": "\"Pwophecy\" wotatow dungeon compweted"
   },
   "2050629406": {
-    "progressDescription": "Iwon Bannew matches compweted as [Stasis] Stasis ow *bwushes* [Void] Void subcwasses"
+    "progressDescription": "Iwon Bannew matches compweted as [Awc] Awc, ow [Void] Void, ow [Stwand] Stwand subcwasses"
   },
   "2177999971": {
     "progressDescription": "Speak to Quinn Waghawi"
   },
   "2258905201": {
-    "progressDescription": "Iwon Bannew matches compweted as [Stasis] Stasis ow *bwushes* [Void] Void subcwasses"
+    "progressDescription": "Iwon Bannew matches compweted as [Awc] Awc, ow [Void] Void, ow [Stwand] Stwand subcwasses"
   },
   "2338381314": {
     "progressDescription": "Speak with Commandew Zavawa"
@@ -55,6 +73,9 @@
   },
   "2656858183": {
     "progressDescription": "\"Tewminaw Ovewwoad\" combatants defeated"
+  },
+  "2752231210": {
+    "progressDescription": "\"Deep Dive\" activities compweted"
   },
   "275339596": {
     "progressDescription": "Cwoud Stwidew bounties compweted"
@@ -71,20 +92,26 @@
   "3118376466": {
     "progressDescription": "Cwucibwe matches compweted"
   },
+  "3121765139": {
+    "progressDescription": "Wegendawy difficuwty \"Defiant Battwegwounds\" activities compweted"
+  },
   "3180884403": {
     "progressDescription": "\"Vauwt of Gwass\" wotatow waid compweted"
   },
-  "3243082817": {
-    "progressDescription": "\"Gwasp of Avawice\" dungeon compweted"
+  "3211393925": {
+    "displayProperties": {
+      "description": "Visit Maws, cowwobowate Osiwis's visions, and intewvene in a potentiaw Vex-based catastwophe."
+    },
+    "progressDescription": "\"Spiwe of da Watchew\" wotatow dungeon compweted"
   },
   "3376767511": {
-    "progressDescription": "Iwon Bannew matches compweted as [Stasis] Stasis ow *bwushes* [Void] Void subcwasses"
+    "progressDescription": "Iwon Bannew matches compweted as [Awc] Awc, ow [Void] Void, ow [Stwand] Stwand subcwasses"
   },
   "3431014262": {
     "progressDescription": "\"Defiant Battwegwounds\" activities compweted"
   },
   "3564470639": {
-    "progressDescription": "Weekwy Campaign mission compweted with a scowe of 100,000 ow highew"
+    "progressDescription": "Weekwy Campaign mission compweted with a high scowe"
   },
   "3826130187": {
     "progressDescription": "\"Deep Stone Cwypt\" wotatow waid compweted"
@@ -95,14 +122,11 @@
   "4026431786": {
     "progressDescription": "Speak with Wowd Shaxx"
   },
-  "4073017996": {
-    "progressDescription": "\"Duawity\" dungeon compweted"
+  "406803827": {
+    "progressDescription": "\"King's Faww\" wotatow waid compweted"
   },
   "4140117227": {
     "progressDescription": "Vanguawd bounties compweted"
-  },
-  "424208044": {
-    "progressDescription": "\"Spiwe of da Watchew\" dungeon compweted"
   },
   "4276867787": {
     "progressDescription": "Competitive pwaywist matches compweted"
@@ -112,6 +136,12 @@
   },
   "565013971": {
     "progressDescription": "Cwucibwe bounties compweted"
+  },
+  "600986371": {
+    "displayProperties": {
+      "description": "Become uuw nightmawe's nightmawe."
+    },
+    "progressDescription": "\"Woot of Nightmawes\" waid compweted"
   },
   "672380795": {
     "progressDescription": "H.E.W.M. Waw Tabwe bounties compweted"

--- a/en-OwO/DestinyPhaseDefinition.json
+++ b/en-OwO/DestinyPhaseDefinition.json
@@ -1,56 +1,56 @@
 {
   "1040714588": {
     "displayProperties": {
-      "name": "Shuwo Chi, da Cowwupted",
-      "description": "Shuwo Chi, an Awoken Techeun who sewves Queen Mawa Sov, was Taken by Owyx and twansfowmed into Shuwo Chi, da Cowwupted. Fwee hew."
+      "description": "Shuwo Chi, an Awoken Techeun who sewves Queen Mawa Sov, was Taken by Owyx and twansfowmed into Shuwo Chi, da Cowwupted. Fwee hew.",
+      "name": "Shuwo Chi, da Cowwupted"
     }
   },
   "1089000747": {
     "displayProperties": {
-      "name": "Owyx",
-      "description": "Dethwone da king."
+      "description": "Dethwone da king.",
+      "name": "Owyx"
     }
   },
   "1126840038": {
     "displayProperties": {
-      "name": "Kawwi, da Cowwupted",
-      "description": "૮ ˶ᵔ ᵕ ᵔ˶ ა Kawwi, an Awoken Techeun who sewves Queen Mawa Sov, was Taken by Owyx and twansfowmed into Kawwi, da Cowwupted. Fwee hew."
+      "description": "૮ ˶ᵔ ᵕ ᵔ˶ ა Kawwi, an Awoken Techeun who sewves Queen Mawa Sov, was Taken by Owyx and twansfowmed into Kawwi, da Cowwupted. Fwee hew.",
+      "name": "Kawwi, da Cowwupted"
     }
   },
   "1327839048": {
     "displayProperties": {
-      "name": "Owacwes",
-      "description": "Countew da Owacwes' song ow be mawked fow negation and wost to time."
+      "description": "Countew da Owacwes' song ow be mawked fow negation and wost to time.",
+      "name": "Owacwes"
     }
   },
   "1327839049": {
     "displayProperties": {
-      "name": "Da Tempwaw",
-      "description": "An extwemewy powewfuw Vex Hydwa, Da Tempwaw is unique in it being a cweatuwe out of time. As such, it can manipuwate weawity in accowdance to da Owacwes' design."
+      "description": "An extwemewy powewfuw Vex Hydwa, Da Tempwaw is unique in it being a cweatuwe out of time. As such, it can manipuwate weawity in accowdance to da Owacwes' design.",
+      "name": "Da Tempwaw"
     }
   },
   "1327839050": {
     "displayProperties": {
-      "name": "Confwuxes",
-      "description": "Secuwe Vex constwucts by (・`ω´・) pweventing Vex sacwifices."
+      "description": "Secuwe Vex constwucts by (・`ω´・) pweventing Vex sacwifices.",
+      "name": "Confwuxes"
     }
   },
   "1406613360": {
     "displayProperties": {
-      "name": "Basiwica",
-      "description": "Infwuence hive wituaw magic by contwowwing annihiwatow totems."
+      "description": "Infwuence hive wituaw magic by contwowwing annihiwatow totems.",
+      "name": "Basiwica"
     }
   },
   "1858926029": {
     "displayProperties": {
-      "name": "Taniks, Webown",
-      "description": "Intewwupt da station's Nucweaw Descent Pwotocow and secuwe it fwom Taniks."
+      "description": "Intewwupt da station's Nucweaw Descent Pwotocow and secuwe it fwom Taniks.",
+      "name": "Taniks, Webown"
     }
   },
   "1942966197": {
     "displayProperties": {
-      "name": "Cowwection",
-      "description": "Subdue and destwoy da abomination."
+      "description": "Subdue and destwoy da abomination.",
+      "name": "Cowwection"
     }
   },
   "196663595": {
@@ -60,91 +60,91 @@
   },
   "2001": {
     "displayProperties": {
-      "name": "Evade da Consecwated Mind",
-      "description": "Evade Vowtaic Ovewwoad chawges and puwsue da Consecwated Mind."
+      "description": "Evade Vowtaic Ovewwoad chawges and puwsue da Consecwated Mind.",
+      "name": "Evade da Consecwated Mind"
     }
   },
   "2002": {
     "displayProperties": {
-      "name": "Summon da Consecwated Mind",
-      "description": "Bypass Vex confwuxes and fowce out da Consecwated Mind fwom hiding."
+      "description": "Bypass Vex confwuxes and fowce out da Consecwated Mind fwom hiding.",
+      "name": "Summon da Consecwated Mind"
     }
   },
   "2003": {
     "displayProperties": {
-      "name": "Defeat da Consecwated Mind",
-      "description": "Once and fow aww, defeat da Consecwated Mind."
+      "description": "Once and fow aww, defeat da Consecwated Mind.",
+      "name": "Defeat da Consecwated Mind"
     }
   },
   "2004": {
     "displayProperties": {
-      "name": "Da Sanctified Mind",
-      "description": "A Vex Axis Mind, da Sanctified Mind amasses contwow ovew many Vex. Defeat it to pwevent fuwthew incuwsions by da Sow Divisive outside of da Bwack Gawden."
+      "description": "A Vex Axis Mind, da Sanctified Mind amasses contwow ovew many Vex. Defeat it to pwevent fuwthew incuwsions by da Sow Divisive outside of da Bwack Gawden.",
+      "name": "Da Sanctified Mind"
     }
   },
   "2115142089": {
     "displayProperties": {
-      "name": "Wawpwiest",
-      "description": "Defeat Owyx's Wawpwiest befowe he destwoys uu."
+      "description": "Defeat Owyx's Wawpwiest befowe he destwoys uu.",
+      "name": "Wawpwiest"
     }
   },
   "2184227225": {
     "displayProperties": {
-      "name": "Macwocosm",
-      "description": "Awign wowwds and defeat da Expwicatow"
+      "description": "Awign wowwds and defeat da Expwicatow.",
+      "name": "Macwocosm"
     }
   },
   "2224793617": {
     "displayProperties": {
-      "description": "Entew da Woot"
+      "description": "Entew da Woot."
     }
   },
   "2392610624": {
     "displayProperties": {
-      "name": "Wiven of a Thousand Voices",
-      "description": "Wiven, da wast known Ahamkawa, fowmewwy in da sewvice of Mawa Sov, was Taken by Owyx. She now cowwupts da city fwom its heawt at da behest of da Hive queen, Savathûn."
+      "description": "Wiven, da wast known Ahamkawa, fowmewwy in da sewvice of Mawa Sov, was Taken by Owyx. She now cowwupts da city fwom its heawt at da behest of da Hive queen, Savathûn.",
+      "name": "Wiven of a Thousand Voices"
     }
   },
   "2776463390": {
     "displayProperties": {
-      "name": "Cwypt Secuwity",
-      "description": "Penetwate da Bway faciwity's secuwity pwotocows and gain access to da Deep Stone Cwypt."
+      "description": "Penetwate da Bway faciwity's secuwity pwotocows and gain access to da Deep Stone Cwypt.",
+      "name": "Cwypt Secuwity"
     }
   },
   "2779782231": {
     "displayProperties": {
-      "name": "૮ ˶ᵔ ᵕ ᵔ˶ ა Nezawec",
-      "description": "End da nightmawe and defeat Nezawec"
+      "description": "End da nightmawe and defeat Nezawec.",
+      "name": "૮ ˶ᵔ ᵕ ᵔ˶ ა Nezawec"
     }
   },
   "2951654489": {
     "displayProperties": {
-      "name": "Da Daughtews",
-      "description": "Intewwupt da da sistews' concentwation."
+      "description": "Intewwupt da da sistews' concentwation.",
+      "name": "Da Daughtews"
     }
   },
   "3172054256": {
     "displayProperties": {
-      "name": "Catacwysm",
-      "description": "Beat back Shadow Wegion fowces and puwsue Nezawec"
+      "description": "Beat back Shadow Wegion fowces and puwsue Nezawec.",
+      "name": "Catacwysm"
     }
   },
   "3738629258": {
     "displayProperties": {
-      "name": "Gowgowoth",
-      "description": "Subdue da abomination."
+      "description": "Subdue da abomination.",
+      "name": "Gowgowoth"
     }
   },
   "3793779769": {
     "displayProperties": {
-      "name": "Atheon, Time's Confwux",
-      "description": "Da Axis Mind wesponsibwe fow bwidging da Vex's own cawcuwations into existence."
+      "description": "Da Axis Mind wesponsibwe fow bwidging da Vex's own cawcuwations into existence.",
+      "name": "Atheon, Time's Confwux"
     }
   },
   "3793779770": {
     "displayProperties": {
-      "name": "Da Gatekeepews",
-      "description": "Pwotectows of da Gwass Thwone, *wuns away* da Gatekeepews awe Vex Hydwas who stand as da Thwone's wast defence."
+      "description": "Pwotectows of da Gwass Thwone, *wuns away* da Gatekeepews awe Vex Hydwas who stand as da Thwone's wast defence.",
+      "name": "Da Gatekeepews"
     }
   },
   "3840791265": {
@@ -154,26 +154,26 @@
   },
   "4035296150": {
     "displayProperties": {
-      "name": "Taniks, da Abomination",
-      "description": "Thwawting Taniks made him gwow stwongew. Destwoy him, once and fow aww..."
+      "description": "Thwawting Taniks made him gwow stwongew. Destwoy him, once and fow aww...",
+      "name": "Taniks, da Abomination"
     }
   },
   "416127450": {
     "displayProperties": {
-      "name": "Atwaks-1",
-      "description": "Countew da sewf-dupwicating, Exo-webown, Atwaks-1."
+      "description": "Countew da sewf-dupwicating, Exo-webown, Atwaks-1.",
+      "name": "Atwaks-1"
     }
   },
   "4249034918": {
     "displayProperties": {
-      "name": "Mowgeth, da Spiwekeepew",
-      "description": "Mowgeth, da Spiwekeepew, an enowmous and powewfuw Taken Ogwe, sewves as *wuns away* da enfowcew of Wiven's cowwuption in da Dweaming City, and da guawd of da City's main towew, Da Keep of Voices. Destwoy them."
+      "description": "Mowgeth, da Spiwekeepew, an enowmous and powewfuw Taken Ogwe, sewves as *wuns away* da enfowcew of Wiven's cowwuption in da Dweaming City, and da guawd of da City's main towew, Da Keep of Voices. Destwoy them.",
+      "name": "Mowgeth, da Spiwekeepew"
     }
   },
   "436847112": {
     "displayProperties": {
-      "name": "Da Vauwt",
-      "description": "A wocking mechanism which secuwes da immensewy powewfuw and tweachewous."
+      "description": "A wocking mechanism which secuwes da immensewy powewfuw and tweachewous.",
+      "name": "Da Vauwt"
     }
   },
   "580855089": {

--- a/en-OwO/DestinyPresentationNodeDefinition.json
+++ b/en-OwO/DestinyPresentationNodeDefinition.json
@@ -1,8 +1,8 @@
 {
   "1000000001": {
     "displayProperties": {
-      "name": "Twansient Twiumphs",
-      "description": "Not aww twiumphs awe fowevew. Some awe avaiwabwe onwy fow a wimited time. This is a devewopew-cuwated wist of twiumphs which wiww become unavaiwabwe next season."
+      "description": "Not aww twiumphs awe fowevew. Some awe avaiwabwe onwy fow a wimited time. This is a devewopew-cuwated wist of twiumphs which wiww become unavaiwabwe next season.",
+      "name": "Twansient Twiumphs"
     }
   },
   "1000000004": {
@@ -27,8 +27,8 @@
   },
   "1000000008": {
     "displayProperties": {
-      "name": "Wedeemabwe",
-      "description": "These embwems can be cowwecting by wedeeming them with a code fow fwee at https://www.bungie.net/wedeem"
+      "description": "These embwems can be cowwected by wedeeming them with a code fow fwee at https://www.bungie.net/wedeem",
+      "name": "Wedeemabwe"
     }
   },
   "1000000051": {

--- a/en-OwO/DestinyTraitDefinition.json
+++ b/en-OwO/DestinyTraitDefinition.json
@@ -1,8 +1,8 @@
 {
   "14342153470": {
     "displayProperties": {
-      "name": "Aww (・`ω´・) Quests",
-      "description": "Aww of da sewected Guawdian's quests"
+      "description": "Aww of da sewected Guawdian's quests",
+      "name": "Aww (・`ω´・) Quests"
     }
   },
   "14342153471": {

--- a/en-OwO/index.ts
+++ b/en-OwO/index.ts
@@ -22,10 +22,12 @@ import DestinyPhaseDefinition from '@Data/manifest/en-OwO/DestinyPhaseDefinition
 import DestinyPresentationNodeDefinition from '@Data/manifest/en-OwO/DestinyPresentationNodeDefinition.json';
 import DestinyRecordDefinition from '@Data/manifest/en-OwO/DestinyRecordDefinition.json';
 import DestinySeasonDefinition from '@Data/manifest/en-OwO/DestinySeasonDefinition.json';
+import DestinySocketCategoryDefinition from '@Data/manifest/en-OwO/DestinySocketCategoryDefinition.json';
 import DestinySourceDefinition from '@Data/manifest/en-OwO/DestinySourceDefinition.json';
 import DestinyStatDefinition from '@Data/manifest/en-OwO/DestinyStatDefinition.json';
 import DestinyTraitDefinition from '@Data/manifest/en-OwO/DestinyTraitDefinition.json';
 
+import DestinyCollectibleDefinitionColloquial from '@Data/manifest/en-OwO/DestinyCollectibleDefinitionColloquial.json';
 import DestinyInventoryItemDefinitionColloquial from '@Data/manifest/en-OwO/DestinyInventoryItemDefinitionColloquial.json';
 
 const enOwO = {
@@ -54,12 +56,14 @@ const enOwO = {
     DestinyPresentationNodeDefinition,
     DestinyRecordDefinition,
     DestinySeasonDefinition,
+    DestinySocketCategoryDefinition,
     DestinySourceDefinition,
     DestinyStatDefinition,
     DestinyTraitDefinition,
   },
   optional: {
     colloquialDefinitions: {
+      DestinyCollectibleDefinition: DestinyCollectibleDefinitionColloquial,
       DestinyInventoryItemDefinition: DestinyInventoryItemDefinitionColloquial,
     },
   },


### PR DESCRIPTION
for some reason it reorders a lot of the key names, even though it's not ordered. the auto cleanup action should fix this though